### PR TITLE
Add possibility to set config from file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Commands:
   dokku config                                    # Display the app's environment variables
   dokku config:get KEY                            # Display an environment variable value
   dokku config:set KEY1=VALUE1 [KEY2=VALUE2 ...]  # Set one or more environment variables
+  dokku config:set:file path/to/file              # Set one or more environment variables from file
   dokku config:unset KEY1 [KEY2 ...]              # Unset one or more environment variables
   dokku domains                                   # List custom domains for the app
   dokku domains:add DOMAIN                        # Add a custom domain to the app

--- a/lib/dokku_cli/config.rb
+++ b/lib/dokku_cli/config.rb
@@ -47,7 +47,7 @@ module DokkuCli
       run_command "config:unset #{app_name} #{args.join(' ')}"
     end
     
-    desc "config:set:file Filename", "Set one or more environment variables from file"
+    desc "config:set:file path/to/file", "Set one or more environment variables from file"
     def config_set_file(config_file)
       config_params = ""
       if File.exists?(config_file)

--- a/lib/dokku_cli/config.rb
+++ b/lib/dokku_cli/config.rb
@@ -46,6 +46,18 @@ module DokkuCli
     def config_unset(*args)
       run_command "config:unset #{app_name} #{args.join(' ')}"
     end
-
+    
+    desc "config:set:file Filename", "Set one or more environment variables from file"
+    def config_set_file(config_file)
+      config_params = ""
+      if File.exists?(config_file)
+        File.open(config_file).each_line do |line|
+          config_params += line.strip + " " unless line.start_with? "#" || line.strip == ""
+        end
+        config_set(config_params)
+      else
+        puts "File #{config_file} does not exist."
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi,

In one of my projects I needed the possibility to set config from a file.

I'm using dotenv to set environment parameters for my rails development and test environment.
The .env file is committed into the repo and every developer can use it as an initial setup.

For the production environment I needed the possibility to set the environment variables without the need of committing it into the repo (sensitive information!).

So I created .env.production which is a simple key/value list (with support for comments) with application configuration for the production environment.

`dokku config:set:file path/to/file` sets the config in the app environment.

The only requirement to use this feature is a file with a key=value list like this:

```
# Secret Key
SECRET_KEY=sfgdfsgsdfgsd92734euhdciuqe872fb2oub39ec8h2bb
# Mailer settings
SMTP_SERVER="smtp.gmail.com"
SMTP_PORT="587"
SMTP_USER="someone@gmail.com"
SMTP_PWD="#######"
```

Regards, Bojan
