### PR TITLE
Update domains.rb

### DIFF
--- a/lib/dokku_cli/domains.rb
+++ b/lib/dokku_cli/domains.rb
@@ -7,7 +7,7 @@ module DokkuCli
     end
 
     desc "domains:add DOMAIN", "Add a custom domain to the app"
-    def domains_set(custom_domain)
+    def domains_add(custom_domain)
       run_command "domains:set #{app_name} #{custom_domain}"
     end
 


### PR DESCRIPTION
The domains:add had no function and would throw:

/Library/Ruby/Gems/2.0.0/gems/dokku-cli-0.1.1/lib/dokku_cli.rb:69:in `method_missing': undefined method`domains_add' for #DokkuCli::Cli:0x007f9d84017998 (NoMethodError)
    from /Library/Ruby/Gems/2.0.0/gems/dokku-cli-0.1.1/lib/dokku_cli.rb:65:in `method_missing'
    from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:29:in`run'
    from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:126:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in`invoke_command'
    from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in`start'
    from /Library/Ruby/Gems/2.0.0/gems/dokku-cli-0.1.1/bin/dokku:5:in `<top (required)>'
    from /usr/bin/dokku:23:in`load'
    from /usr/bin/dokku:23:in `<main>'
