### PR TITLE
Fixed the --remote option

### DIFF
--- a/lib/dokku_cli.rb
+++ b/lib/dokku_cli.rb
@@ -91,7 +91,7 @@ module DokkuCli
         exit unless File.exist?(git_config)
 
         git_config = File.read(git_config)
-        match = git_config.match(/\[remote "#{remote}"\]\n\turl \= dokku@(.*):(.*)\n/).to_a
+        match = git_config.match(/\[remote "#{remote}"\]\s+url \= dokku@(.*):(.*)$/).to_a
         exit unless match
 
         match
@@ -99,6 +99,7 @@ module DokkuCli
     end
 
     def run_command(command)
+      command = command.gsub(/ --remote=[\S]*/, '')
       dokku_command = "ssh -t dokku@#{domain} #{command}"
 
       puts "Running #{dokku_command}..."


### PR DESCRIPTION
I've fixed the --remote option that was broken.
Main problems:
1) the regexp for catch the remote reposity was wrong
2) the --remote option was attached in the command run on the dokku host
