### PR TITLE
Fix the --remote option to work application wide

### DIFF
--- a/lib/dokku_cli.rb
+++ b/lib/dokku_cli.rb
@@ -77,14 +77,6 @@ module DokkuCli
       super
     end
 
-    def method_missing(method, *args, &block)
-      if method.to_s.split(":").length >= 2
-        self.send(method.to_s.gsub(":", "_").gsub("-", "_"), *args)
-      else
-        super
-      end
-    end
-
     private
 
     def app_name

--- a/lib/dokku_cli.rb
+++ b/lib/dokku_cli.rb
@@ -27,6 +27,8 @@ module DokkuCli
       if args.empty?
         run_command "logs #{app_name}"
       else
+        # remove unnecessary mapped remote option
+        args = args.gsub(/-remote [\S]*/, '')
         command = "ssh -p #{port} dokku@#{domain} logs #{app_name} #{args}"
         puts "Running #{command}..."
         exec(command)

--- a/lib/dokku_cli.rb
+++ b/lib/dokku_cli.rb
@@ -51,6 +51,7 @@ module DokkuCli
         run_command "run #{app_name} #{command}"
       end
     end
+    map "run" => "walk"
 
     desc "ssh", "Start an SSH session as root user"
     def ssh
@@ -77,8 +78,6 @@ module DokkuCli
     def method_missing(method, *args, &block)
       if method.to_s.split(":").length >= 2
         self.send(method.to_s.gsub(":", "_").gsub("-", "_"), *args)
-      elsif method == :run
-        self.walk(*args)
       else
         super
       end

--- a/lib/dokku_cli.rb
+++ b/lib/dokku_cli.rb
@@ -35,7 +35,7 @@ module DokkuCli
 
     desc "open", "Open the app in your default browser"
     def open
-      url = %x[dokku urls].split("\r").first
+      url = %x[dokku urls --remote #{app_name}].split("\r").first
       exec("open #{url}")
     end
 

--- a/lib/dokku_cli/certs.rb
+++ b/lib/dokku_cli/certs.rb
@@ -1,6 +1,12 @@
 module DokkuCli
   class Cli < Thor
 
+    map "certs:add" => "certs_add",
+        "certs:generate" => "certs_generate",
+        "certs:info" => "certs_info",
+        "certs:remove" => "certs_remove",
+        "certs:update" => "certs_update"
+
     desc "certs:add CRT KEY", "Add an ssl endpoint to an app. Can also import from a tarball on stdin."
     def certs_add(crt, key)
       run_command "certs:add #{app_name} #{crt} #{key}"
@@ -22,7 +28,7 @@ module DokkuCli
     end
 
     desc "certs:update CRT KEY", "Update an SSL Endpoint on an app. Can also import from a tarball on stdin"
-    def certs_remove(crt, key)
+    def certs_update(crt, key)
       run_command "certs:update #{app_name} #{crt} #{key}"
     end
   end

--- a/lib/dokku_cli/config.rb
+++ b/lib/dokku_cli/config.rb
@@ -1,6 +1,11 @@
 module DokkuCli
   class Cli < Thor
 
+    map "config:get" => "config_get",
+        "config:set" => "config_set",
+        "config:unset" => "config_unset",
+        "config:set:file" => "config_set_file"
+
     desc "config", "Display the app's environment variables"
     def config
       run_command "config #{app_name}"

--- a/lib/dokku_cli/domains.rb
+++ b/lib/dokku_cli/domains.rb
@@ -1,6 +1,10 @@
 module DokkuCli
   class Cli < Thor
 
+    map "domains:add" => "domains_add",
+        "domains:clear" => "domains_clear",
+        "domains:remove" => "domains_remove"
+
     desc "domains", "List custom domains for the app"
     def domains
       run_command "domains #{app_name}"

--- a/lib/dokku_cli/events.rb
+++ b/lib/dokku_cli/events.rb
@@ -1,6 +1,10 @@
 module DokkuCli
   class Cli < Thor
 
+    map "events:list" => "events_list",
+        "events:on" => "events_on",
+        "events:off" => "events_off"
+
     desc "events", "Show the last events (-t follows)"
     def events
       run_command "events #{app_name}"

--- a/lib/dokku_cli/keys.rb
+++ b/lib/dokku_cli/keys.rb
@@ -1,6 +1,8 @@
 module DokkuCli
   class Cli < Thor
 
+    map "keys:add" => "keys_add"
+
     desc "keys:add PATH DESCRIPTION", "Add the ssh key to your dokku machine."
     def keys_add(path, description)
       command = "cat #{path} | ssh -p #{port} root@#{domain} 'sudo sshcommand acl-add dokku #{description}'"

--- a/lib/dokku_cli/nginx.rb
+++ b/lib/dokku_cli/nginx.rb
@@ -1,6 +1,10 @@
 module DokkuCli
   class Cli < Thor
 
+    map "nginx:build" => "nginx_build",
+        "nginx:access-logs" => "nginx_access_logs",
+        "nginx:error-logs" => "nginx_error_logs"
+
     desc "nginx:build", "(Re)builds nginx config for the app"
     def nginx_build
       run_command "nginx:build-config #{app_name}"

--- a/lib/dokku_cli/ps.rb
+++ b/lib/dokku_cli/ps.rb
@@ -1,6 +1,10 @@
 module DokkuCli
   class Cli < Thor
 
+    map "ps:rebuild" => "ps_rebuild",
+        "ps:restart" => "ps_restart",
+        "ps:start" => "ps_start"
+
     desc "ps", "List processes running in app container(s)"
     def ps
       run_command "ps #{app_name}"


### PR DESCRIPTION
The `--remote` global option is currently not working in run, open, logs commands.
This pull request fixes the `--remote` option to work application wide.

For details on the run command.
When using method_missing, the `--remote` option not to passing the walk method.
So, I use not method_missing but map option of the thor.
https://github.com/erikhuda/thor/wiki#basic-usage

This pull request also fixes https://github.com/SebastianSzturo/dokku-cli/issues/15

Thanks.
